### PR TITLE
Improved parameter parsing of nested FormRequests + QoL

### DIFF
--- a/src/Console/Commands/GenerateSwaggerCommand.php
+++ b/src/Console/Commands/GenerateSwaggerCommand.php
@@ -7,7 +7,7 @@ use Smoggert\SwaggerGenerator\Services\SwaggerGeneratorService;
 
 class GenerateSwaggerCommand extends Command
 {
-    protected $signature = 'swagger:generate {--format=yaml}';
+    protected $signature = 'swagger:generate {--format=json}';
 
     protected $description = 'Generate swagger documentation based on your api routes';
 

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -105,7 +105,6 @@ class SwaggerGeneratorService
 
     protected function filterRoutes(): void
     {
-        $non_excluded_routes = new RouteCollection();
 
         $allowed_routes = Config::get('swagger_gen.allowed');
         $excluded_routes = Config::get('swagger_gen.excluded');
@@ -113,6 +112,8 @@ class SwaggerGeneratorService
         $all_tags = new Collection();
 
         foreach ($excluded_routes as $excluded_route) {
+            $non_excluded_routes = new RouteCollection();
+
             $escaped_excluded_route = str_replace('/', '\/', $excluded_route);
             $excluded = str_replace('{id}', "[a-zA-Z0-9-:\}\{]+", $escaped_excluded_route);
             foreach ($this->routes as $route) {
@@ -128,7 +129,7 @@ class SwaggerGeneratorService
             $escaped_allowed_route = str_replace('/', '\/', $stripped_allowed_route);
             $twice_stripped_allowed_route = str_replace('{id}', "[a-zA-Z0-9-:\}\{]+", $escaped_allowed_route);
 
-            foreach ($non_excluded_routes as $route) {
+            foreach ($this->routes as $route) {
                 $tags = [];
                 if (preg_match('/'.$twice_stripped_allowed_route.'/s', $route->uri, $tags)) {
                     array_shift($tags);

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -385,6 +385,7 @@ class SwaggerGeneratorService
         $schemes = [];
         foreach ($this->security_schemes as $security_scheme) {
             $schemes[$security_scheme['name']] = $security_scheme;
+            unset($schemes[$security_scheme['name']]['name']);
         }
 
         return $schemes;

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -473,7 +473,7 @@ class SwaggerGeneratorService
 
     protected function addQueryParameter($property_name, $property_info,array &$parameters,array &$other_properties)
     {
-        if(str_contains("*", $property_name) && $this->getEnumFromRule($property_info)) {
+        if(str_contains($property_name,"*") && $this->getEnumFromRule($property_info)) {
             return;
         }
 

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -587,39 +587,23 @@ class SwaggerGeneratorService
             $rule = explode($rule, '|');
         }
 
-        if(in_array([
-            'string',
-            'date',
-            'email',
-            'ip'
-        ],$rule)) {
-            return 'string';
-        };
-
-        if(in_array([
-            'integer',
-            'int'
-        ],$rule)) {
-            return 'integer';
-        };
-
-        if(in_array([
-            'numeric'
-        ],$rule)) {
+        if(in_array('numeric',$rule)) {
             return 'number';
         };
 
-        if(in_array([
-            'boolean'
-        ],$rule)) {
+        if(in_array('boolean',$rule)) {
             return 'boolean';
         };
 
-        if(in_array([
-            'array'
-        ],$rule)) {
+        if(in_array('array',$rule)) {
             return 'array';
         };
+
+        if(in_array('integer',$rule) || in_array('int',$rule)) {
+            return 'integer';
+        };
+
+        // default to string !
 
         return 'string';
     }

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -473,6 +473,10 @@ class SwaggerGeneratorService
 
     protected function addQueryParameter($property_name, $property_info,array &$parameters,array &$other_properties)
     {
+        if(str_contains("*", $property_name) && $this->getEnumFromRule($property_info)) {
+            return;
+        }
+
         $type = $this->getPropertyType($property_info);
         $name = $type === 'array' ? $property_name.'[]' : $property_name;
 

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -369,7 +369,7 @@ class SwaggerGeneratorService
 
     protected function getRequestParameters(\ReflectionClass $request): array
     {
-        return $request->newInstance()->rules();
+        return Arr::undot($request->newInstance()->rules());
     }
 
     protected function addComponents(array &$swagger_docs): void
@@ -470,11 +470,21 @@ class SwaggerGeneratorService
         }
     }
 
-    protected function addProperty(string $property_name, $property_info, &$component): void
+    protected function addProperty(string $property_name, $property_rule, &$component): void
     {
-        $property = [
-            'type' => $this->getPropertyType($property_info),
-        ];
+        $property_rule = is_string($property_rule) ? explode('|',$property_rule) : $property_rule;
+
+        if(! array_diff_key($property_rule,array_keys(array_keys($property_rule)))) {
+            $property = [
+                'type' => $this->getPropertyType($property_rule),
+            ];
+        } else {
+            $property = [
+                'type' => 'object',
+                'required' => $this->getRequiredParameters($property_rule),
+                'properties' => $this->getProperties($property_rule),
+            ];
+        }
 
         $component[$property_name] = $property;
     }

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -581,26 +581,46 @@ class SwaggerGeneratorService
         return [];
     }
 
-    protected function getPropertyType($info): string
+    protected function getPropertyType($rule): string
     {
-        if (is_string($info)) {
-            if (str_contains($info, 'string') || str_contains($info, 'date') || str_contains($info, 'email') || str_contains($info, 'ip')) {
-                return 'string';
-            } elseif (str_contains($info, 'integer')) {
-                return 'integer';
-            } elseif (str_contains($info, 'numeric')) {
-                return 'number';
-            } elseif (str_contains($info, 'bool')) {
-                return 'boolean';
-            } elseif (str_contains($info, 'array')) {
-                return 'array';
-            } elseif (str_contains($info, 'int')) {
-                Log::alert('Possible use of `int´ statement. Due to possible mismatches this type should be declared as integer.');
-
-                return 'string';
-            }
+        if (is_string($rule)) {
+            $rule = explode($rule, '|');
         }
-        //default to string
+
+        if(in_array([
+            'string',
+            'date',
+            'email',
+            'ip'
+        ],$rule)) {
+            return 'string';
+        };
+
+        if(in_array([
+            'integer',
+            'int'
+        ],$rule)) {
+            return 'integer';
+        };
+
+        if(in_array([
+            'numeric'
+        ],$rule)) {
+            return 'number';
+        };
+
+        if(in_array([
+            'boolean'
+        ],$rule)) {
+            return 'boolean';
+        };
+
+        if(in_array([
+            'array'
+        ],$rule)) {
+            return 'array';
+        };
+
         return 'string';
     }
 

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -495,7 +495,7 @@ class SwaggerGeneratorService
 
     protected function addQueryParameter($property_name, $property_info,array &$parameters,array &$other_properties)
     {
-        if(str_contains($property_name,"*") && $this->getEnumFromRule($property_info)) {
+        if(str_ends_with($property_name,".*")) {
             return;
         }
 

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -475,23 +475,33 @@ class SwaggerGeneratorService
         }
     }
 
-    protected function hasSubParameters(array $array) : bool
+    protected function hasObjects(array $array) : bool
     {
         return isset($array['*']);
+    }
+
+    protected function hasSubParameters(array $array) : bool
+    {
+        if (empty($array)) {
+            return false;
+        }
+        return array_keys($array) !== range(0, count($array) - 1);
     }
 
     protected function addProperty(string $property_name, $property_rule, &$component): void
     {
         $property_rule = is_string($property_rule) ? explode('|',$property_rule) : $property_rule;
 
-        if(! $this->hasSubParameters($property_rule)) {
-            $property = [
-                'type' => $this->getPropertyType($property_rule),
-            ];
-        } elseif(! $this->hasSubParameters($property_rule['*'])) {
-            $property = [
-                'type' => 'array',
-            ];
+        if(! $this->hasObjects($property_rule)) {
+            if($this->hasSubParameters($property_rule)) {
+                $property = [
+                    'type' => 'array',
+                ];
+            } else {
+                $property = [
+                    'type' => $this->getPropertyType($property_rule),
+                ];
+            }
         } else {
             $property = [
                 'type' => 'object',

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -462,7 +462,10 @@ class SwaggerGeneratorService
     {
         $properties = [];
         foreach ($parameters as $parameter_name => $parameter_info) {
-            $this->addProperty($parameter_name, $is_resource ? "string" : $parameter_info , $properties);
+            if(! is_numeric($parameter_name))
+            {
+                $this->addProperty($parameter_name, $is_resource ? "string" : $parameter_info , $properties);
+            }
         }
 
         return $properties;
@@ -507,6 +510,11 @@ class SwaggerGeneratorService
         } else {
             $property = [
                 'type' => 'array',
+                'items' => [
+                    'type' => 'object',
+                    'required' => $this->getRequiredParameters($property_rule),
+                    'properties' => $this->getProperties($property_rule),
+                ]
             ];
         }
 

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -153,30 +153,14 @@ class SwaggerGeneratorService
 
     public function addAuthentication(&$swagger_docs)
     {
-        foreach ($this->authMiddleware as $key => $scheme) {
-            $this->addScheme($key, $scheme);
+        foreach ($this->authMiddleware as $key => $middleware) {
+            $this->addMiddleware($key, $middleware);
         }
     }
 
-    protected function addScheme(string $key, array $scheme): void
+    protected function addMiddleware(string $key, array $middleware): void
     {
-        if ($security_scheme = $this->buildScheme($scheme['type'], $scheme['parameters'] ?? null)) {
-            $this->security_schemes[$key] = [
-                'scheme' => $security_scheme,
-                'name' => $scheme['name'] ?? $key,
-            ];
-        }
-    }
-
-    protected function buildScheme(string $type, ?array $scheme_parameters): ?array
-    {
-        $type_method = "get{$type}AuthScheme";
-        if (\method_exists($this, $type_method)) {
-            return $scheme_parameters ? $this->$type_method($scheme_parameters) : $this->$type_method();
-        } else {
-            Log::error("Supplied auth type: {$type} is not supported.");
-            return null;
-        }
+            $this->security_schemes[$key] = $middleware['schema'];
     }
 
     protected function addPaths(&$swagger_docs)
@@ -745,41 +729,5 @@ class SwaggerGeneratorService
     protected function addInfo(&$object): void
     {
         $object['info'] = Config::get('swagger_gen.info');
-    }
-
-    protected function getBasicAuthScheme(): array
-    {
-        return [
-            'type' => 'http',
-            'scheme' => 'basic',
-        ];
-    }
-
-    protected function getBearerAuthScheme(): array
-    {
-        return [
-            'type' => 'http',
-            'scheme' => 'bearer',
-        ];
-    }
-
-    protected function getApiKeyAuthScheme(array $params): array
-    {
-        $api_key_auth = [
-            'type' => 'apiKey',
-            'in' => $params['in'],
-        ];
-
-        $api_key_auth['name'] = $params['name'] ?? 'apiKey';
-
-        return $api_key_auth;
-    }
-
-    protected function getOpenIDAuthScheme(array $params)
-    {
-        return [
-            'type' => 'openIdConnect',
-            'openIdConnectUrl' => $params['openIdUri'] ?? '',
-        ];
     }
 }

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -484,7 +484,7 @@ class SwaggerGeneratorService
     {
         $property_rule = is_string($property_rule) ? explode('|',$property_rule) : $property_rule;
 
-        if($this->hasSubParameters($property_rule)) {
+        if(! $this->hasSubParameters($property_rule)) {
             $property = [
                 'type' => $this->getPropertyType($property_rule),
             ];

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -495,7 +495,9 @@ class SwaggerGeneratorService
         if(! $this->hasObjects($property_rule)) {
             if($this->hasSubParameters($property_rule)) {
                 $property = [
-                    'type' => 'array',
+                    'type' => 'object',
+                    'required' => $this->getRequiredParameters($property_rule),
+                    'properties' => $this->getProperties($property_rule),
                 ];
             } else {
                 $property = [
@@ -504,9 +506,7 @@ class SwaggerGeneratorService
             }
         } else {
             $property = [
-                'type' => 'object',
-                'required' => $this->getRequiredParameters($property_rule),
-                'properties' => $this->getProperties($property_rule),
+                'type' => 'array',
             ];
         }
 

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -376,8 +376,18 @@ class SwaggerGeneratorService
     {
         $components = [];
         $components['schemas'] = $this->schemas;
-        $components['securitySchemes'] = $this->security_schemes;
+        $components['securitySchemes'] = $this->mappedschemes();
         $swagger_docs['components'] = $components;
+    }
+
+    protected function mappedSchemes(): array
+    {
+        $schemes = [];
+        foreach ($this->security_schemes as $security_scheme) {
+            $schemes[$security_scheme['name']] = $security_scheme['scheme'];
+        }
+
+        return $schemes;
     }
 
     protected function createRequestBodyComponent(array $parameters, string $requestName): string

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -423,7 +423,7 @@ class SwaggerGeneratorService
             return $this->wrapString('#/components/schemas/'.$resource_name);
         }
 
-        return $null;
+        return null;
     }
 
     protected function trimRequestPath(string $requestName): string

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -528,7 +528,7 @@ class SwaggerGeneratorService
         }
 
         $type = $this->getPropertyType($property_info);
-        $name = $type === 'array' ? $property_name.'[]' : $property_name;
+        $name = ($type === 'array') ? $property_name.'[]' : $property_name;
 
         $param = [
             'name' => $name,
@@ -584,7 +584,7 @@ class SwaggerGeneratorService
     protected function getPropertyType($rule): string
     {
         if (is_string($rule)) {
-            $rule = explode($rule, '|');
+            $rule = explode( '|',$rule);
         }
 
         if(in_array('numeric',$rule)) {

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -113,7 +113,8 @@ class SwaggerGeneratorService
         $all_tags = new Collection();
 
         foreach ($excluded_routes as $excluded_route) {
-            $excluded = str_replace('{id}', "[a-zA-Z0-9-:\}\{]+", $excluded_route);
+            $escaped_excluded_route = str_replace('/', '\/', $excluded_route);
+            $excluded = str_replace('{id}', "[a-zA-Z0-9-:\}\{]+", $escaped_excluded_route);
             foreach ($this->routes as $route) {
                 if (! preg_match('/'.$excluded.'/s', $route->uri)) {
                     $non_excluded_routes->add($route);

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -120,6 +120,7 @@ class SwaggerGeneratorService
                     $non_excluded_routes->add($route);
                 }
             }
+            $this->routes = $non_excluded_routes;
         }
 
         foreach ($allowed_routes as $allowed_route) {

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -416,7 +416,7 @@ class SwaggerGeneratorService
         if (isset($resource_name)) {
             if ($this->responseClassIsJsonResource($reflection)) {
                 if ($this->responseClassIsResourceCollection($reflection)) {
-                    $parameters = $reflection->newInstance(new Collection())->toArray(request());
+                    $parameters = $reflection->newInstance(new Collection([new Model()]))->toArray(request());
                 } else {
                     $parameters = $reflection->newInstance(new Model())->toArray(request());
                 }

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -384,7 +384,7 @@ class SwaggerGeneratorService
     {
         $schemes = [];
         foreach ($this->security_schemes as $security_scheme) {
-            $schemes[$security_scheme['name']] = $security_scheme['scheme'];
+            $schemes[$security_scheme['name']] = $security_scheme;
         }
 
         return $schemes;

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -424,7 +424,7 @@ class SwaggerGeneratorService
                 if (! isset($this->schemas[$resource_name])) {
                     $component = [
                         'type' => 'object',
-                        'properties' => $this->getProperties($parameters),
+                        'properties' => $this->getPropertiesFromResource($parameters),
                     ];
                     $this->schemas[$resource_name] = $component;
                 }
@@ -453,11 +453,16 @@ class SwaggerGeneratorService
         return str_replace('\\', '', $requestName);
     }
 
-    protected function getProperties(array $parameters): array
+    protected function getPropertiesFromResource(array $parameters) : array
+    {
+        return $this->getProperties($parameters, true);
+    }
+
+    protected function getProperties(array $parameters, bool $is_resource = false): array
     {
         $properties = [];
         foreach ($parameters as $parameter_name => $parameter_info) {
-            $this->addProperty($parameter_name, $parameter_info, $properties);
+            $this->addProperty($parameter_name, $is_resource ? "string" : $parameter_info , $properties);
         }
 
         return $properties;

--- a/src/Services/SwaggerGeneratorService.php
+++ b/src/Services/SwaggerGeneratorService.php
@@ -470,13 +470,22 @@ class SwaggerGeneratorService
         }
     }
 
+    protected function hasSubParameters(array $array) : bool
+    {
+        return isset($array['*']);
+    }
+
     protected function addProperty(string $property_name, $property_rule, &$component): void
     {
         $property_rule = is_string($property_rule) ? explode('|',$property_rule) : $property_rule;
 
-        if(! array_diff_key($property_rule,array_keys(array_keys($property_rule)))) {
+        if($this->hasSubParameters($property_rule)) {
             $property = [
                 'type' => $this->getPropertyType($property_rule),
+            ];
+        } elseif(! $this->hasSubParameters($property_rule['*'])) {
+            $property = [
+                'type' => 'array',
             ];
         } else {
             $property = [

--- a/src/config/swagger_gen.php
+++ b/src/config/swagger_gen.php
@@ -16,7 +16,7 @@ return [
 
     'servers' => [
         [
-            'url' => 'http://{tenant:demo}.test.test/api/v1',
+            'url' => 'https://{subdomain:test}.test.test/api/v1',
             'description' => 'My dev server',
         ],
     ],
@@ -40,19 +40,43 @@ return [
     *   This defines the exact routes that won't be included.
     *   Indicate resource related parameters with {id}
     */
+
     'exclude' => [
           // 'api/v1/resources/{id}'
     ],
 
+
     /* -----------------------------
     *  Define your auth middlewares
     *  -----------------------------
-    *   When defined this will apply the security scheme to each route where the middleware or middlewaregroup is encountered.
-    *   Supported types: basic, bearer, apiKey:<header|name>, apiKey:<request> ,openId:<url-here>
+    *   When defined this will apply the security scheme to each route where the middleware or middleware-group is encountered.
+    *   Possible schemes: https://swagger.io/docs/specification/authentication/
+    *
+    *   Syntax is a bit double with the alias & class reference, but this is due to how Laravel's Console kernel messes with Middleware.
     */
 
+
     'middleware' => [
-        // 'api' => 'openId:https://myapi.example.com/open-idconfig;optional_name'
+/*        'auth:api' => [
+            'class' => \App\Http\Middleware\Authenticate::class . ":api",
+            'schema' => [
+                'name' => 'MyOauthToken',
+                'type' => 'oauth2',
+                'scheme' => 'bearer',
+                'description' => "Authorization code flow for 3rd party implementations. !! 'client_id' & 'client_secret' !! passed in the body for token fetching with grant_type code.",
+                'bearerFormat' => 'JWT',
+                'flows' => [
+                    'authorizationCode' => [
+                        'authorizationUrl' => "https://test.test/oauth/authorize",
+                        'tokenUrl'=> "https://test.test/oauth/token",
+                        'refreshUrl' => "https://test.test/oauth/token/refresh",
+                        'scopes' => [
+                            'scope' => 'Explain scope',
+                        ]
+                    ]
+                ]
+            ]
+        ]*/
     ],
 
     /* -----------------------------

--- a/src/config/swagger_gen.php
+++ b/src/config/swagger_gen.php
@@ -21,7 +21,7 @@ return [
         ],
     ],
 
-    'output' => storage_path('text.txt'),
+    //'output' => storage_path('text.txt'),
 
 /* -----------------------------
     *  Define your allowed routes

--- a/src/config/swagger_gen.php
+++ b/src/config/swagger_gen.php
@@ -23,15 +23,25 @@ return [
 
     //'output' => storage_path('text.txt'),
 
-/* -----------------------------
+    /* -----------------------------
     *  Define your allowed routes
     *  -----------------------------
     *   This defines the prefixes that will be required to index the routes from your application.
-    *   You can index the tag related to the prefix with /{$tag}
+    *   You can index the tag related to the prefix with /{$tag}, skip resource related parameters with {id}
     */
 
     'allowed' => [
         'api/v1/{$tag}',
+    ],
+
+    /* -----------------------------
+    *  Define your excluded routes
+    *  -----------------------------
+    *   This defines the exact routes that won't be included.
+    *   Indicate resource related parameters with {id}
+    */
+    'exclude' => [
+          // 'api/v1/resources/{id}'
     ],
 
     /* -----------------------------

--- a/src/config/swagger_gen.php
+++ b/src/config/swagger_gen.php
@@ -21,11 +21,9 @@ return [
         ],
     ],
 
-    'output' => [
-        'path' => storage_path('text.txt'),
-    ],
+    'output' => storage_path('text.txt'),
 
-    /* -----------------------------
+/* -----------------------------
     *  Define your allowed routes
     *  -----------------------------
     *   This defines the prefixes that will be required to index the routes from your application.


### PR DESCRIPTION
Better parsing of all kinds of things.

Resource collection parsing is still a bit of a mess, mostly because of how it gets resolved.
I would have to "manually" resolve most of the resources as laravel seemingly refuses to just turn the syntax into simple arrays alltogether.

Need to update a few lines regarding url param parsing to better reflect their "types". This is mostly an OpenAPI syntax thing I need to look at. When that's done It's probably a new major version or something.